### PR TITLE
added installation switch for the case you don't want to launch the cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ moodle_enable_debug: true
 ```
 By default, debug mode is off for Moodle. To enable debug mode use the set the `moodle_enable_debug` variable to `true`.
 
+```yaml
+launch_install: false
+```
+By defaut, this role launches the cli installation, you may not want to launch it, in this case set the `launch_install` variable to false
+
 ## Dependencies
 None.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 moodle_enable_debug: false
+launch_installation: true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -81,5 +81,5 @@
     --agree-license
   args:
     chdir: "{{ moodle_root_path }}/admin/cli"
-  when: not moodle_installed.stat.exists and launch_install is true
+  when: not (moodle_installed.stat.exists) and (launch_installation == true)
   changed_when: moodle_cloned.changed

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -81,5 +81,5 @@
     --agree-license
   args:
     chdir: "{{ moodle_root_path }}/admin/cli"
-  when: not moodle_installed.stat.exists
+  when: not moodle_installed.stat.exists and launch_install is true
   changed_when: moodle_cloned.changed


### PR DESCRIPTION
I use your role to deploy my moodle, If i want to use it for cluster servers it can be interesting to not launch cli installation on all instances.